### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol server
 
 This is a TypeScript-based MCP server that provides tools to fetch Python documentation using the Brave Search API.
 
+<a href="https://glama.ai/mcp/servers/8xhmttyi7e">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/8xhmttyi7e/badge" alt="Python Docs Server MCP server" />
+</a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [Python Docs Server](https://glama.ai/mcp/servers/8xhmttyi7e) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/8xhmttyi7e">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/8xhmttyi7e/badge" alt="Python Docs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.